### PR TITLE
Link -lbrcmEGL before -lbrcmGLESv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ VCLIBDIR =$(SDKSTAGE)/opt/vc/lib
 INCLUDES += -I$(ILCDIR) -I$(VCINCDIR) -I$(VCINCDIR)/interface/vcos/pthreads
 INCLUDES += -I$(VCINCDIR)/interface/vmcs_host/linux
 
-LDLIBS  += -lbcm_host -lvcos -lvchiq_arm -lopenmaxil -lbrcmGLESv2 -lbrcmEGL -lpthread -lrt
+LDLIBS  += -lbcm_host -lvcos -lvchiq_arm -lopenmaxil -lbrcmEGL -lbrcmGLESv2 -lpthread -lrt
 LDLIBS  += -Wl,--whole-archive $(ILCDIR)/libilclient.a -Wl,--no-whole-archive
 LDFLAGS += -L$(VCLIBDIR)
 


### PR DESCRIPTION
On Debian Bookworm, when using the libraries installed by `buildme` from
raspberrypi/userland@14b90ff9d9f031391a299e6e006965d02bfd1bb1
VDR would refuse to start up:
```sh
LD_LIBRARY_PATH=/opt/vc/lib vdr -v /tmp -Prpihddevice
vdr: /opt/vc/lib/libEGL.so: undefined symbol: glPointSizePointerOES
```
With the preinstalled raspberry-userland on Raspberry OS Legacy
this change is not necessary.
(Perhaps it should be `-lbrcmGLESv2 -lbrcmEGL -lbrcmGLESv2` so that it would work everywhere? I am not familiar with OpenGL, and I did not test this change on Raspberry OS Legacy.)

Note: VDR does not yet start on my system, possibly because I did nothing special to configure the GPU memory:
```
* failed to open vchiq instance
```