### PR TITLE
Fix a crash in ilclient_teardown_tunnels()

### DIFF
--- a/omx.c
+++ b/omx.c
@@ -572,6 +572,9 @@ int cOmx::DeInit(void)
 	while (Active())
 		cCondWait::SleepMs(5);
 
+	for (int i = 0; i < eNumTunnels; i++)
+		ilclient_disable_tunnel(&m_tun[i]);
+
 	ilclient_teardown_tunnels(m_tun);
 	ilclient_state_transition(m_comp, OMX_StateIdle);
 	ilclient_state_transition(m_comp, OMX_StateLoaded);


### PR DESCRIPTION
In 05bf186eb1606c741068737c7b3f49e8032d21b4 the calls to ilclient_disable_tunnel() were removed. These calls are actually necessary on some hardware or firmware revisions, as demonstrated by the following assertion failure:

ilclient.c:524:ilclient_teardown_tunnels():error == OMX_ErrorNone

Closes #9