### PR TITLE
Replace some sleeps with condition variables

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -921,7 +921,6 @@ public:
 		if (!Ready())
 			return 0;
 
-		m_mutex.Lock();
 		int copied = 0;
 
 		if (sampleFormat == AV_SAMPLE_FMT_NONE)
@@ -996,25 +995,21 @@ public:
 			}
 #endif
 		}
-		m_mutex.Unlock();
 		return copied;
 	}
 
 	void Flush(void)
 	{
-		m_mutex.Lock();
 		if (m_running)
 			m_omx->StopAudio();
 		m_configured = false;
 		m_running = false;
 		m_pts = 0;
-		m_mutex.Unlock();
 	}
 
 	void SetCodec(cAudioCodec::eCodec codec, unsigned int channels,
 			unsigned int samplingRate, unsigned int frameSize)
 	{
-		m_mutex.Lock();
 		if (codec != cAudioCodec::eInvalid && channels > 0)
 		{
 			m_inChannels = channels;
@@ -1057,7 +1052,6 @@ public:
 			m_resamplerConfigured = false;
 #endif
 		}
-		m_mutex.Unlock();
 	}
 
 	bool IsPassthrough(void)
@@ -1139,7 +1133,6 @@ private:
 	}
 #endif
 
-	cMutex		        m_mutex;
 	cOmx		        *m_omx;
 
 	cRpiAudioPort::ePort m_port;

--- a/audio.c
+++ b/audio.c
@@ -101,29 +101,25 @@ public:
 
 	cAudioCodec::eCodec GetCodec(void)
 	{
-		if (!m_parsed)
-			Parse();
+		Parse();
 		return m_codec;
 	}
 
 	unsigned int GetChannels(void)
 	{
-		if (!m_parsed)
-			Parse();
+		Parse();
 		return m_channels;
 	}
 
 	unsigned int GetSamplingRate(void)
 	{
-		if (!m_parsed)
-			Parse();
+		Parse();
 		return m_samplingRate;
 	}
 
 	unsigned int GetFrameSize(void)
 	{
-		if (!m_parsed)
-			Parse();
+		Parse();
 		return m_packet.size;
 	}
 
@@ -146,8 +142,7 @@ public:
 
 	bool Empty(void)
 	{
-		if (!m_parsed)
-			Parse();
+		Parse();
 		return m_packet.size == 0;
 	}
 
@@ -244,7 +239,7 @@ public:
 
 		m_mutex.Unlock();
 	}
-	
+
 private:
 
 	cParser(const cParser&);
@@ -260,13 +255,15 @@ private:
 
 	void Parse()
 	{
-		m_mutex.Lock();
-
 		cAudioCodec::eCodec codec = cAudioCodec::eInvalid;
 		unsigned int channels = 0;
 		unsigned int offset = 0;
 		unsigned int frameSize = 0;
 		unsigned int samplingRate = 0;
+
+		m_mutex.Lock();
+		if (m_parsed)
+			goto done;
 
 		while (m_size - offset >= 4)
 		{
@@ -352,8 +349,9 @@ private:
 		else
 			m_packet.size = 0;
 
-		m_mutex.Unlock();
 		m_parsed = true;
+	done:
+		m_mutex.Unlock();
 	}
 
 	struct Pts

--- a/audio.c
+++ b/audio.c
@@ -19,7 +19,6 @@
 
 #include "audio.h"
 #include "setup.h"
-#include "omx.h"
 
 #include <vdr/tools.h>
 #include <vdr/remux.h>
@@ -75,7 +74,6 @@ extern "C" {
 #endif
 }
 
-#include <queue>
 #include <string.h>
 
 #define AVPKT_BUFFER_SIZE (KILOBYTE(256))

--- a/omx.c
+++ b/omx.c
@@ -17,18 +17,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <queue>
-
 #include "omx.h"
 #include "display.h"
 #include "setup.h"
 
 #include <vdr/tools.h>
-#include <vdr/thread.h>
-
-extern "C" {
-#include "ilclient.h"
-}
 
 #include "bcm_host.h"
 
@@ -72,60 +65,6 @@ default: \
 	(s).eChannelMapping[0] = OMX_AUDIO_ChannelLF; \
 	(s).eChannelMapping[1] = OMX_AUDIO_ChannelRF; \
 	break; }
-
-class cOmxEvents
-{
-
-public:
-
-	enum eEvent {
-		ePortSettingsChanged,
-		eConfigChanged,
-		eEndOfStream,
-		eBufferEmptied
-	};
-
-	struct Event
-	{
-		Event(eEvent _event, int _data)
-			: event(_event), data(_data) { };
-		eEvent 	event;
-		int		data;
-	};
-
-	~cOmxEvents()
-	{
-		while (!m_events.empty())
-		{
-			delete m_events.front();
-			m_events.pop();
-		}
-	}
-
-	Event* Get(void)
-	{
-		Event* event = 0;
-		m_mutex.Lock();
-		if (!m_events.empty())
-		{
-			event = m_events.front();
-			m_events.pop();
-		}
-		m_mutex.Unlock();
-		return event;
-	}
-
-	void Add(Event* event)
-	{
-		m_mutex.Lock();
-		m_events.push(event);
-		m_mutex.Unlock();
-	}
-
-private:
-	cMutex		m_mutex;
-	std::queue<Event*> m_events;
-};
 
 const char* cOmx::errStr(int err)
 {
@@ -180,70 +119,71 @@ const char* cOmx::errStr(int err)
 void cOmx::Action(void)
 {
 	cTimeMs timer;
+	m_mutex.Lock();
 	while (Running())
 	{
-		while (cOmxEvents::Event* event = m_portEvents->Get())
+		while (m_portEvents.empty())
+			if (m_portEventsAdded.TimedWait(m_mutex, 10))
+				goto timeout;
+
 		{
-			switch (event->event)
+			const Event event = m_portEvents.front();
+			m_portEvents.pop();
+			m_mutex.Unlock();
+
+			switch (event.event)
 			{
-			case cOmxEvents::ePortSettingsChanged:
-				if (m_handlePortEvents)
-					HandlePortSettingsChanged(event->data);
+			case Event::eShutdown:
+				return;
+
+			case Event::ePortSettingsChanged:
+				HandlePortSettingsChanged(event.data);
 				break;
 
-			case cOmxEvents::eConfigChanged:
-				switch (event->data)
+			case Event::eConfigChanged:
+				switch (event.data)
 				{
 				case OMX_IndexParamBrcmPixelAspectRatio:
-					if (m_handlePortEvents)
-						HandlePortSettingsChanged(131);
+					HandlePortSettingsChanged(131);
 					break;
 				case OMX_IndexConfigBufferStall:
 					if (IsBufferStall() && !IsClockFreezed() && m_onBufferStall)
 						m_onBufferStall(m_onBufferStallData);
-					break;
-				default:
-					break;
 				}
 				break;
 
-			case cOmxEvents::eEndOfStream:
-				if (event->data == 90 && m_onEndOfStream)
+			case Event::eEndOfStream:
+				if (event.data == 90 && m_onEndOfStream)
 					m_onEndOfStream(m_onEndOfStreamData);
 				break;
 
-			case cOmxEvents::eBufferEmptied:
-				HandlePortBufferEmptied((eOmxComponent)event->data);
-				break;
-
-			default:
-				break;
+			case Event::eBufferEmptied:
+				HandlePortBufferEmptied((eOmxComponent)event.data);
 			}
 
-			delete event;
+			m_mutex.Lock();
 		}
-		cCondWait::SleepMs(10);
 
+timeout:
 		if (timer.TimedOut())
 		{
 			timer.Set(100);
-			Lock();
 			memmove(m_usedAudioBuffers, m_usedAudioBuffers + 1,
 				(sizeof m_usedAudioBuffers) -
 				sizeof *m_usedAudioBuffers);
 			memmove(m_usedVideoBuffers, m_usedVideoBuffers + 1,
 				(sizeof m_usedVideoBuffers) -
 				sizeof *m_usedVideoBuffers);
-			Unlock();
 		}
 	}
+	m_mutex.Unlock();
 }
 
 bool cOmx::PollVideo(void)
 {
-	Lock();
+	m_mutex.Lock();
 	int used = m_usedVideoBuffers[0];
-	Unlock();
+	m_mutex.Unlock();
 	return used < OMX_VIDEO_BUFFERS * 9 / 10;
 }
 
@@ -251,20 +191,20 @@ void cOmx::GetBufferUsage(int &audio, int &video)
 {
 	audio = 0;
 	video = 0;
-	Lock();
+	m_mutex.Lock();
 	for (int i = 0; i < BUFFERSTAT_FILTER_SIZE; i++)
 	{
 		audio += m_usedAudioBuffers[i];
 		video += m_usedVideoBuffers[i];
 	}
-	Unlock();
+	m_mutex.Unlock();
 	audio /= BUFFERSTAT_FILTER_SIZE * OMX_AUDIO_BUFFERS / 100;
 	video /= BUFFERSTAT_FILTER_SIZE * OMX_VIDEO_BUFFERS / 100;
 }
 
 void cOmx::HandlePortBufferEmptied(eOmxComponent component)
 {
-	Lock();
+	m_mutex.Lock();
 
 	switch (component)
 	{
@@ -280,11 +220,14 @@ void cOmx::HandlePortBufferEmptied(eOmxComponent component)
 		ELOG("HandlePortBufferEmptied: invalid component!");
 		break;
 	}
-	Unlock();
+	m_mutex.Unlock();
 }
 
 void cOmx::HandlePortSettingsChanged(unsigned int portId)
 {
+	if (!m_handlePortEvents)
+		return;
+
 	Lock();
 	DBG("HandlePortSettingsChanged(%d)", portId);
 
@@ -409,38 +352,42 @@ void cOmx::HandlePortSettingsChanged(unsigned int portId)
 	Unlock();
 }
 
+void cOmx::Add(const cOmx::Event& event)
+{
+	m_mutex.Lock();
+	m_portEventsAdded.Broadcast();
+	m_portEvents.push(event);
+	m_mutex.Unlock();
+}
+
 void cOmx::OnBufferEmpty(void *instance, COMPONENT_T *comp)
 {
 	cOmx* omx = static_cast <cOmx*> (instance);
-	omx->m_portEvents->Add(
-			new cOmxEvents::Event(cOmxEvents::eBufferEmptied,
-					comp == omx->m_comp[eVideoDecoder] ? eVideoDecoder :
-					comp == omx->m_comp[eAudioRender] ? eAudioRender :
-							eInvalidComponent));
+	omx-> Add(Event(Event::eBufferEmptied,
+			comp == omx->m_comp[eVideoDecoder]
+			? eVideoDecoder
+			: comp == omx->m_comp[eAudioRender]
+			? eAudioRender
+			: eInvalidComponent));
 }
 
 void cOmx::OnPortSettingsChanged(void *instance, COMPONENT_T *comp, OMX_U32 data)
 {
-	cOmx* omx = static_cast <cOmx*> (instance);
-	omx->m_portEvents->Add(
-			new cOmxEvents::Event(cOmxEvents::ePortSettingsChanged, data));
+	static_cast<cOmx*>(instance)->
+		Add(Event(Event::ePortSettingsChanged, data));
 }
 
 void cOmx::OnConfigChanged(void *instance, COMPONENT_T *comp, OMX_U32 data)
 {
-	cOmx* omx = static_cast <cOmx*> (instance);
-	omx->m_portEvents->Add(
-			new cOmxEvents::Event(cOmxEvents::eConfigChanged, data));
+	static_cast<cOmx*>(instance)->Add(Event(Event::eConfigChanged, data));
 }
 
 void cOmx::OnEndOfStream(void *instance, COMPONENT_T *comp, OMX_U32 data)
 {
-	cOmx* omx = static_cast <cOmx*> (instance);
-	omx->m_portEvents->Add(
-			new cOmxEvents::Event(cOmxEvents::eEndOfStream, data));
+	static_cast<cOmx*>(instance)->Add(Event(Event::eEndOfStream, data));
 }
 
-void cOmx::OnError(void *instance, COMPONENT_T *comp, OMX_U32 data)
+void cOmx::OnError(void *, COMPONENT_T *, OMX_U32 data)
 {
 	if ((OMX_S32)data != OMX_ErrorSameState)
 		ELOG("OmxError(%s)", errStr((int)data));
@@ -456,7 +403,7 @@ cOmx::cOmx() :
 	m_spareVideoBuffers(0),
 	m_clockReference(eClockRefNone),
 	m_clockScale(0),
-	m_portEvents(new cOmxEvents()),
+	m_portEvents(),
 	m_handlePortEvents(false),
 	m_onBufferStall(0),
 	m_onBufferStallData(0),
@@ -474,11 +421,6 @@ cOmx::cOmx() :
 	m_videoFrameFormat.height = 0;
 	m_videoFrameFormat.frameRate = 0;
 	m_videoFrameFormat.scanMode = cScanMode::eProgressive;
-}
-
-cOmx::~cOmx()
-{
-	delete m_portEvents;
 }
 
 int cOmx::Init(int display, int layer)
@@ -572,8 +514,7 @@ int cOmx::Init(int display, int layer)
 
 int cOmx::DeInit(void)
 {
-	Cancel(-1);
-	m_portEvents->Add(0);
+	Add(Event(Event::eShutdown, 0));
 
 	while (Active())
 		cCondWait::SleepMs(5);

--- a/ovgosd.c
+++ b/ovgosd.c
@@ -103,11 +103,10 @@ public:
 
 	static cOvgFont *Get(const char *name)
 	{
-		if (!s_fonts)
-			Init();
+		Init();
 
 		cOvgFont *font;
-		for (font = s_fonts->First(); font; font = s_fonts->Next(font))
+		for (font = s_fonts.First(); font; font = s_fonts.Next(font))
 			if (!strcmp(font->Name(), name))
 				return font;
 
@@ -120,7 +119,7 @@ public:
 			{
 				delete font;
 				font = 0;
-				s_fonts->Clear();
+				s_fonts.Clear();
 				if (!retry)
 				{
 					ELOG("[OpenVG] out of memory - failed to load font!");
@@ -130,14 +129,13 @@ public:
 				retry = false;
 			}
 		}
-		s_fonts->Add(font);
+		s_fonts.Add(font);
 		return font;
 	}
 
 	static void CleanUp(void)
 	{
-		delete s_fonts;
-		s_fonts = 0;
+		s_fonts.Clear();
 
 		if (FT_Done_FreeType(s_ftLib))
 			ELOG("failed to deinitialize FreeType library!");
@@ -249,8 +247,7 @@ private:
 
 	static void Init(void)
 	{
-		s_fonts = new cList<cOvgFont>;
-		if (FT_Init_FreeType(&s_ftLib))
+		if (!s_ftLib && FT_Init_FreeType(&s_ftLib))
 			ELOG("failed to initialize FreeType library!");
 	}
 
@@ -370,11 +367,11 @@ private:
 	FT_Face m_face;
 
 	static FT_Library s_ftLib;
-	static cList<cOvgFont> *s_fonts;
+	static cList<cOvgFont> s_fonts;
 };
 
 FT_Library cOvgFont::s_ftLib = 0;
-cList<cOvgFont> *cOvgFont::s_fonts = 0;
+cList<cOvgFont> cOvgFont::s_fonts;
 
 /* ------------------------------------------------------------------------- */
 

--- a/ovgosd.c
+++ b/ovgosd.c
@@ -2346,8 +2346,7 @@ public:
 
 		tArea area = { r.Left(), r.Top(), r.Right(), r.Bottom(), 32 };
 
-		for (int i = 0; i < m_pixmaps.Size(); i++)
-			m_pixmaps[i] = NULL;
+		memset(&m_pixmaps[0], 0, m_pixmaps.Size() * sizeof m_pixmaps[0]);
 
 		return cOsd::SetAreas(&area, 1);
 	}

--- a/ovgosd.h
+++ b/ovgosd.h
@@ -43,9 +43,7 @@ protected:
 	virtual void DropImageData(int ImageHandle);
 
 private:
-
-	cOvgThread *m_ovg;
-	static cRpiOsdProvider *s_instance;
+	static cOvgThread *s_ovg;
 };
 
 #endif

--- a/setup.h
+++ b/setup.h
@@ -167,7 +167,7 @@ public:
 
 	static void SetHDMIChannelMapping(bool passthrough, int channels);
 
-	static cRpiSetup* GetInstance(void);
+	static cRpiSetup* GetInstance(void) { return &s_instance; }
 	static void DropInstance(void);
 
 	class cMenuSetupPage* GetSetupPage(void);
@@ -181,8 +181,6 @@ public:
 	bool ProcessArgs(int argc, char *argv[]);
 	const char *CommandLineHelp(void);
 
-private:
-
 	cRpiSetup() :
 		m_mpeg2Enabled(false),
 		m_onAudioSetupChanged(0),
@@ -191,10 +189,9 @@ private:
 		m_onVideoSetupChangedData(0)
 	{ }
 
-	virtual ~cRpiSetup() { };
+	static cRpiSetup s_instance;
 
-	static cRpiSetup* s_instance;
-
+private:
 	AudioParameters  m_audio;
 	VideoParameters  m_video;
 	OsdParameters    m_osd;


### PR DESCRIPTION
I was hoping that this would allow the plugin to work with a smaller GPU memory. It actually did start up with `gpu_mem=128`, displaying a HD channel, which I think previously only worked with `gpu_mem=192`. Still, after pressing the Menu button 4 times (to show and hide full-screen OSD twice) it was unable to open any more full-screen OSD menu at `gpu_mem=128`.

On a quick test, the OSD still seems to be fine.