### PR TITLE
Make use of some C++11, and reduce the amount of system calls

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -186,11 +186,7 @@ public:
 			memcpy(m_packet.data + m_size, data, length);
 			m_size += length;
 			memset(m_packet.data + m_size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
-#if __cplusplus >= 201101L
 			m_ptsQueue.emplace(Pts(pts, length));
-#else
-			m_ptsQueue.push(Pts(pts, length));
-#endif
 
 			m_parsed = false;
 		}

--- a/omx.c
+++ b/omx.c
@@ -363,7 +363,7 @@ void cOmx::Add(const cOmx::Event& event)
 {
 	m_mutex.Lock();
 	m_portEventsAdded.Broadcast();
-	m_portEvents.push(event);
+	m_portEvents.emplace(event);
 	m_mutex.Unlock();
 }
 

--- a/omx.c
+++ b/omx.c
@@ -196,7 +196,7 @@ void cOmx::GetBufferUsage(int &audio, int &video)
 	audio = 0;
 	video = 0;
 	Lock();
-	for (int i = 0; i < BUFFERSTAT_FILTER_SIZE; i++)
+	for (size_t i = 0; i < BUFFERSTAT_FILTER_SIZE; i++)
 	{
 		audio += m_usedAudioBuffers[i];
 		video += m_usedVideoBuffers[i];
@@ -400,34 +400,12 @@ void cOmx::OnError(void *, COMPONENT_T *, OMX_U32 data)
 		ELOG("OmxError(%s)", errStr((int)data));
 }
 
-cOmx::cOmx() :
-	cThread(),
-	m_client(NULL),
-	m_setAudioStartTime(false),
-	m_setVideoStartTime(false),
-	m_setVideoDiscontinuity(false),
-	m_spareAudioBuffers(0),
-	m_spareVideoBuffers(0),
-	m_clockReference(eClockRefNone),
-	m_clockScale(0),
-	m_portEvents(),
-	m_handlePortEvents(false),
-	m_onBufferStall(0),
-	m_onBufferStallData(0),
-	m_onEndOfStream(0),
-	m_onEndOfStreamData(0),
-	m_onStreamStart(0),
-	m_onStreamStartData(0)
+cOmx::cOmx()
 {
 	memset(m_tun, 0, sizeof(m_tun));
 	memset(m_comp, 0, sizeof(m_comp));
 	memset(m_usedAudioBuffers, 0, sizeof m_usedAudioBuffers);
 	memset(m_usedVideoBuffers, 0, sizeof m_usedVideoBuffers);
-
-	m_videoFrameFormat.width = 0;
-	m_videoFrameFormat.height = 0;
-	m_videoFrameFormat.frameRate = 0;
-	m_videoFrameFormat.scanMode = cScanMode::eProgressive;
 }
 
 int cOmx::Init(int display, int layer)

--- a/omx.h
+++ b/omx.h
@@ -23,6 +23,7 @@
 #include <vdr/thread.h>
 #include "tools.h"
 #include <queue>
+#include <atomic>
 
 extern "C"
 {
@@ -110,12 +111,12 @@ public:
 	OMX_BUFFERHEADERTYPE* GetAudioBuffer(int64_t pts = OMX_INVALID_PTS);
 	OMX_BUFFERHEADERTYPE* GetVideoBuffer(int64_t pts = OMX_INVALID_PTS);
 
-	bool PollVideo(void);
+	bool PollVideo(void) const;
 
 	bool EmptyAudioBuffer(OMX_BUFFERHEADERTYPE *buf);
 	bool EmptyVideoBuffer(OMX_BUFFERHEADERTYPE *buf);
 
-	void GetBufferUsage(int &audio, int &video);
+	void GetBufferUsage(int &audio, int &video) const;
 
 private:
 	struct Event
@@ -176,8 +177,9 @@ private:
 	bool m_setVideoStartTime = false;
 	bool m_setVideoDiscontinuity = false;
 	static constexpr size_t BUFFERSTAT_FILTER_SIZE = 64;
-	int m_usedAudioBuffers[BUFFERSTAT_FILTER_SIZE];
-	int m_usedVideoBuffers[BUFFERSTAT_FILTER_SIZE];
+	std::atomic<unsigned> m_bufferStat;
+	std::atomic<int16_t> m_usedAudioBuffers[BUFFERSTAT_FILTER_SIZE];
+	std::atomic<int16_t> m_usedVideoBuffers[BUFFERSTAT_FILTER_SIZE];
 
 	OMX_BUFFERHEADERTYPE* m_spareAudioBuffers = nullptr;
 	OMX_BUFFERHEADERTYPE* m_spareVideoBuffers = nullptr;
@@ -201,6 +203,9 @@ private:
 	/** pointer to cOmxDevice::OnStreamStart(); constant after Init() */
 	void (*m_onStreamStart)(void*) = nullptr;
 	void *m_onStreamStartData = nullptr;
+
+	unsigned GetCurrentStat(void) const
+	{ return m_bufferStat.load(std::memory_order_relaxed) % BUFFERSTAT_FILTER_SIZE; }
 
 	void HandlePortBufferEmptied(eOmxComponent component);
 	void HandlePortSettingsChanged(unsigned int portId);

--- a/omx.h
+++ b/omx.h
@@ -187,9 +187,9 @@ private:
 	OMX_S32 m_clockScale = 0;
 	bool m_handlePortEvents = false;
 
-	cMutex m_mutex;
+	pthread_mutex_t m_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-	cCondVar m_portEventsAdded;
+	pthread_cond_t m_portEventsAdded = PTHREAD_COND_INITIALIZER;
 	std::queue<Event> m_portEvents;
 
 	/** pointer to cOmxDevice::OnBufferStall(); constant after Init() */

--- a/omx.h
+++ b/omx.h
@@ -163,7 +163,7 @@ private:
 		eNumTunnels
 	};
 
-	ILCLIENT_T 	*m_client;
+	ILCLIENT_T 	*m_client = nullptr;
 	COMPONENT_T	*m_comp[cOmx::eNumComponents + 1];
 	TUNNEL_T 	 m_tun[cOmx::eNumTunnels + 1];
 
@@ -172,18 +172,18 @@ private:
 	cVideoFrameFormat m_videoFrameFormat;
 
 	/* The following fields are protected by cThread::mutex */
-	bool m_setAudioStartTime;
-	bool m_setVideoStartTime;
-	bool m_setVideoDiscontinuity;
-#define BUFFERSTAT_FILTER_SIZE 64
+	bool m_setAudioStartTime = false;
+	bool m_setVideoStartTime = false;
+	bool m_setVideoDiscontinuity = false;
+	static constexpr size_t BUFFERSTAT_FILTER_SIZE = 64;
 	int m_usedAudioBuffers[BUFFERSTAT_FILTER_SIZE];
 	int m_usedVideoBuffers[BUFFERSTAT_FILTER_SIZE];
 
-	OMX_BUFFERHEADERTYPE* m_spareAudioBuffers;
-	OMX_BUFFERHEADERTYPE* m_spareVideoBuffers;
-	eClockReference	m_clockReference;
-	OMX_S32 m_clockScale;
-	bool m_handlePortEvents;
+	OMX_BUFFERHEADERTYPE* m_spareAudioBuffers = nullptr;
+	OMX_BUFFERHEADERTYPE* m_spareVideoBuffers = nullptr;
+	eClockReference	m_clockReference = eClockRefNone;
+	OMX_S32 m_clockScale = 0;
+	bool m_handlePortEvents = false;
 
 	cMutex m_mutex;
 
@@ -191,16 +191,16 @@ private:
 	std::queue<Event> m_portEvents;
 
 	/** pointer to cOmxDevice::OnBufferStall(); constant after Init() */
-	void (*m_onBufferStall)(void*);
-	void *m_onBufferStallData;
+	void (*m_onBufferStall)(void*) = nullptr;
+	void *m_onBufferStallData = nullptr;
 
 	/** pointer to cOmxDevice::OnEndOfStream(); constant after Init() */
-	void (*m_onEndOfStream)(void*);
-	void *m_onEndOfStreamData;
+	void (*m_onEndOfStream)(void*) = nullptr;
+	void *m_onEndOfStreamData = nullptr;
 
 	/** pointer to cOmxDevice::OnStreamStart(); constant after Init() */
-	void (*m_onStreamStart)(void*);
-	void *m_onStreamStartData;
+	void (*m_onStreamStart)(void*) = nullptr;
+	void *m_onStreamStartData = nullptr;
 
 	void HandlePortBufferEmptied(eOmxComponent component);
 	void HandlePortSettingsChanged(unsigned int portId);

--- a/tools.h
+++ b/tools.h
@@ -203,16 +203,12 @@ public:
 class cVideoFrameFormat
 {
 public:
-
-	cVideoFrameFormat() : width(0), height(0), frameRate(0),
-		scanMode(cScanMode::eProgressive), pixelWidth(0), pixelHeight(0) { };
-
-	int width;
-	int height;
-	int frameRate;
-	cScanMode::eMode scanMode;
-	int pixelWidth;
-	int pixelHeight;
+	int width = 0;
+	int height = 0;
+	int frameRate = 0;
+	cScanMode::eMode scanMode = cScanMode::eProgressive;
+	int pixelWidth = 0;
+	int pixelHeight = 0;
 
 	bool Interlaced(void) const {
 		return cScanMode::Interlaced(scanMode);
@@ -224,6 +220,7 @@ class cRational
 public:
 
 	cRational(double d);
+	cRational() = delete;
 	cRational(int _num, int _den) : num(_num), den(_den) { }
 
 	bool Reduce(int max);
@@ -233,7 +230,6 @@ public:
 
 private:
 
-	cRational();
 	static int Gcd(int u, int v);
 };
 


### PR DESCRIPTION
GCC 4.8.5 was the first version to support ISO/IEC 14882:2011 (C++11). The first Raspbian version to support C++11 probably was Raspbian Wheezy, based on Debian 7, whose long-term support (LTS) ended in May 2018.

As of this writing, the newest Debian that is out of long term support (since June 2022) is Debian 9 ("Stretch"). It shipped with GCC 6.3.0, which supported C++11 by default (without explicit `-std=c++11`). Because all currently supported GNU/Linux distributions that can run on Raspberry Pi should include a compiler that is compatible with C++11 by default, it should be safe to use C++11.

We will make use of C++11 `std::atomic` to make operations around `cOmx::m_usedAudioBuffers[]` and `cOmx::m_usedAudioBuffers[]` lock-free.