### PR TITLE
Fix the compilation with Raspberry OS Bullseye and Bookworm

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -54,8 +54,8 @@ protected:
 
 	struct Codec
 	{
-		class AVCodec		 *codec;
-	    class AVCodecContext *context;
+		const class AVCodec	*codec;
+		class AVCodecContext	*context;
 	};
 
 private:

--- a/omx.c
+++ b/omx.c
@@ -398,14 +398,6 @@ void cOmx::OnError(void *, COMPONENT_T *, OMX_U32 data)
 		ELOG("OmxError(%s)", errStr((int)data));
 }
 
-cOmx::cOmx()
-{
-	memset(m_tun, 0, sizeof(m_tun));
-	memset(m_comp, 0, sizeof(m_comp));
-	memset(m_usedAudioBuffers, 0, sizeof m_usedAudioBuffers);
-	memset(m_usedVideoBuffers, 0, sizeof m_usedVideoBuffers);
-}
-
 int cOmx::Init(int display, int layer)
 {
 	m_client = ilclient_init();
@@ -966,7 +958,7 @@ int cOmx::SetVideoCodec(cVideoCodec::eCodec codec)
 
 	param.nBufferSize = OMX_VIDEO_BUFFERSIZE;
 	param.nBufferCountActual = OMX_VIDEO_BUFFERS;
-	memset(m_usedVideoBuffers, 0, sizeof m_usedVideoBuffers);
+	memset((void*) m_usedVideoBuffers, 0, sizeof m_usedVideoBuffers);
 
 	if (OMX_SetParameter(ILC_GET_HANDLE(m_comp[eVideoDecoder]),
 			OMX_IndexParamPortDefinition, &param) != OMX_ErrorNone)
@@ -1133,7 +1125,7 @@ int cOmx::SetupAudioRender(cAudioCodec::eCodec outputFormat, int channels,
 
 	param.nBufferSize = OMX_AUDIO_BUFFERSIZE;
 	param.nBufferCountActual = OMX_AUDIO_BUFFERS;
-	memset(m_usedAudioBuffers, 0, sizeof m_usedAudioBuffers);
+	memset((void*) m_usedAudioBuffers, 0, sizeof m_usedAudioBuffers);
 
 	if (OMX_SetParameter(ILC_GET_HANDLE(m_comp[eAudioRender]),
 			OMX_IndexParamPortDefinition, &param) != OMX_ErrorNone)

--- a/omx.h
+++ b/omx.h
@@ -38,8 +38,7 @@ class cOmx : public cThread
 {
 
 public:
-
-	cOmx();
+	cOmx() = default;
 	int Init(int display, int layer);
 	int DeInit(void);
 
@@ -165,8 +164,8 @@ private:
 	};
 
 	ILCLIENT_T 	*m_client = nullptr;
-	COMPONENT_T	*m_comp[cOmx::eNumComponents + 1];
-	TUNNEL_T 	 m_tun[cOmx::eNumTunnels + 1];
+	COMPONENT_T	*m_comp[cOmx::eNumComponents + 1] = {};
+	TUNNEL_T 	 m_tun[cOmx::eNumTunnels + 1] = {};
 
 	/* Updated by Action() thread;
 	read by callers of GetVideoFrameFormat() (without holding a mutex!) */
@@ -178,8 +177,8 @@ private:
 	bool m_setVideoDiscontinuity = false;
 	static constexpr size_t BUFFERSTAT_FILTER_SIZE = 64;
 	std::atomic<unsigned> m_bufferStat;
-	std::atomic<int16_t> m_usedAudioBuffers[BUFFERSTAT_FILTER_SIZE];
-	std::atomic<int16_t> m_usedVideoBuffers[BUFFERSTAT_FILTER_SIZE];
+	std::atomic<int16_t> m_usedAudioBuffers[BUFFERSTAT_FILTER_SIZE] = {};
+	std::atomic<int16_t> m_usedVideoBuffers[BUFFERSTAT_FILTER_SIZE] = {};
 
 	OMX_BUFFERHEADERTYPE* m_spareAudioBuffers = nullptr;
 	OMX_BUFFERHEADERTYPE* m_spareVideoBuffers = nullptr;


### PR DESCRIPTION
I upgraded to a newer Raspberry Pi OS today. Its compiler emits some new warnings due to #16.

cOmx::cOmx(): Use the default constructor with C++11 member initializers.

cOmx::SetVideoCodec(), cOmx::SetupAudioRender(): Add a C-style cast to (void*) in order to silence the warning. This is ugly, but there does not appear to be any better way.