### PR TITLE
Avoid SIGSEGV on avcodec_send_packet()

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -1405,7 +1405,7 @@ void cRpiAudioDecoder::Action(void)
 				AVPacket * const packet = m_parser->Packet();
 				bool do_sleep = false;
 				if (!pending_len &&
-				    (!(pending_len = packet->size) ||
+				    (!(pending_len = packet->size) || !ctx ||
 				     avcodec_send_packet(ctx, packet) < 0))
 				{
 					do_sleep = true;


### PR DESCRIPTION
Around a discontinuity in an edited recording, we may end up with `ctx=NULL`. avcodec_send_packet() is unconditionally dereferencing that pointer, so we must not invoke it on a null pointer.

When a crash was observed, the packet `pts` and `dts` were `LLONG_MIN` and the `size` was 576.

This fixes up commit 95ca44c16441a09696e76b9f3ef1a080abda91e3